### PR TITLE
Update getting-started-for-web.phtml

### DIFF
--- a/app/views/docs/getting-started-for-web.phtml
+++ b/app/views/docs/getting-started-for-web.phtml
@@ -64,7 +64,7 @@ $demos = $platform['demos'] ?? [];
 <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
     <pre class="line-numbers"><code class="prism language-javascript" data-prism>const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
-    .setProject('[PROJECT_ID]');               // Your project ID
+    .setProject('64cd173b3c113749be37');         // Your project ID
 </code></pre>
 </div>
 
@@ -108,7 +108,7 @@ client.subscribe('files', response => {
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
-    .setProject('[PROJECT_ID]');               // Your project ID
+    .setProject('64cd173b3c113749be37');               // Your project ID
 
 const account = new Account(client);
 


### PR DESCRIPTION
As a newbie to Appwrite, it wasn't clear where to find the Project Id. I thought the name of my project, "MyProject", was sufficient, but it wasn't and it caused me to get a CORS error when trying to use my project. Later, I discovered the "Project ID" tag was clickable, and it gave me my project Id.

This proposed change would be an improvement, as it shows the expected format of a project id. The best change would be a UI change in the project overview page of the Appwrite Web UI.

I mentioned this [in the general channel in Discord](https://discord.com/channels/564160730845151244/564160731327758347/1139617256070991922) and it sounded like you'd like to have this improved, so here's a start on that.